### PR TITLE
feat: clean up on the remove event

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working [development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development).
 
 You can create an environment for development with `tox`:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/juju/charm-helpers#egg=charmhelpers
-ops
+ops<3
 git+https://opendev.org/openstack/charm-ops-openstack#egg=ops_openstack
 jinja2
 netifaces

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
-# Copyright 2024 Canonical Ltd
+
+ # Copyright 2024 Canonical Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,8 +53,7 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
         self.register_status_check(self.resource_status)
         self.register_status_check(self.install_status)
 
-        self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.remove, self._on_remove)
+        self.framework.observe(self.on.remove, self.on_remove)
 
     def _get_debian_package_path(self) -> Optional[Path]:
         """Return the path to the debian package if it has been provided.
@@ -113,13 +113,13 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
         options = [(x, y) for x, y in raw_options if y]
         return options
 
-    def _on_install(self, event):
+    def on_install(self, event):
         super().on_install(event)
         self.create_connector()
         self.install_sdc()
         self.update_status()
 
-    def _on_remove(self, event):
+    def on_remove(self, event):
         """Handle the remove event."""
         self.remove_connector()
         if self.uninstall_sdc():

--- a/src/charm.py
+++ b/src/charm.py
@@ -203,7 +203,7 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
         # Get the MDM IP from config file
         sdc_mdm_ips = config["powerflex-sdc-mdm-ips"]
         # Install the SDC package
-        install_cmd = ["sudo", "env", f"MDM_IP={sdc_mdm_ips}", "dpkg", "-i", str(sdc_package_file)]
+        install_cmd = ["sudo", f"MDM_IP={sdc_mdm_ips}", "dpkg", "-i", str(sdc_package_file)]
         logger.info("Installing SDC kernel module with MDM(s) %s", sdc_mdm_ips)
         self.model.unit.status = model.MaintenanceStatus("Installing SDC kernel module")
         result = subprocess.run(install_cmd, capture_output=True, text=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -46,11 +47,13 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
         self._stored.installed = False
         self._stored.install_failed = False
         self._stored.is_started = True
+        self._stored.sdc_package_name = None
 
         self.register_status_check(self.resource_status)
         self.register_status_check(self.install_status)
 
         self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.remove, self._on_remove)
 
     def _get_debian_package_path(self) -> Optional[Path]:
         """Return the path to the debian package if it has been provided.
@@ -116,6 +119,20 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
         self.install_sdc()
         self.update_status()
 
+    def _on_remove(self, event):
+        """Handle the remove event."""
+        self.remove_connector()
+        if self.uninstall_sdc():
+            # Update the stored state to be tidy, but realistically this won't
+            # end up being used, given that the charm is being removed.
+            self._stored.installed = False
+            self._stored.install_failed = False
+            self._stored.is_started = False
+
+        # Similarly, the status of the unit will only momentarily be relevant,
+        # since the unit is about to be removed, but we update it to be tidy.
+        self.update_status()
+
     def create_connector(self):
         """Create the connector.conf file and populate with data."""
         config = dict(self.framework.model.config)
@@ -155,6 +172,13 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
             perms=0o600,
         )
 
+    def remove_connector(self):
+        """Remove the connector.conf file, if it exists."""
+        connector_file_path = os.path.join(CONNECTOR_DIR, CONNECTOR_FILE)
+        if os.path.exists(connector_file_path):
+            os.remove(connector_file_path)
+            logger.info("Removed connector.conf file at %s", connector_file_path)
+
     def install_sdc(self):
         """Enable access to the PowerFlex volumes."""
         config = dict(self.framework.model.config)
@@ -164,13 +188,25 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
             logger.error("The package required for SDC installation is missing")
             return
 
+        # Store the name of the SDC package for later use.
+        result = subprocess.run(
+            ["dpkg", "--info", str(sdc_package_file)],
+            capture_output=True,
+            text=True,
+        )
+        mo = re.search(r"^\s*Package:\s+(.+?)$", result.stdout, re.MULTILINE)
+        if mo:
+            self._stored.sdc_package_name = mo.group(1)
+        else:
+            logger.warning("Couldn't determine package name from %s", sdc_package_file)
+
         # Get the MDM IP from config file
         sdc_mdm_ips = config["powerflex-sdc-mdm-ips"]
         # Install the SDC package
-        install_cmd = f"sudo MDM_IP={sdc_mdm_ips} dpkg -i {sdc_package_file}"
+        install_cmd = ["sudo", "env", f"MDM_IP={sdc_mdm_ips}", "dpkg", "-i", str(sdc_package_file)]
         logger.info("Installing SDC kernel module with MDM(s) %s", sdc_mdm_ips)
         self.model.unit.status = model.MaintenanceStatus("Installing SDC kernel module")
-        result = subprocess.run(install_cmd.split(), capture_output=True, text=True)
+        result = subprocess.run(install_cmd, capture_output=True, text=True)
         exit_code = result.returncode
 
         # If the installation process failed, then log the error and return
@@ -191,6 +227,26 @@ class NovaComputePowerFlexCharm(ops_openstack.core.OSBaseCharm):
             logger.info("SDC scini service running. SDC Installation complete.")
         else:
             logger.error("SDC scini service has encountered errors while starting")
+
+    def uninstall_sdc(self):
+        """Remove the SDC package if it is installed."""
+        if not self._stored.installed:
+            # Not installed is 'success'.
+            return True
+        if not self._stored.sdc_package_name:
+            logger.error("SDC package name is not stored, cannot remove SDC package")
+            return False
+        remove_cmd = ["sudo", "apt", "remove", "-y", self._stored.sdc_package_name]
+        result = subprocess.run(remove_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            logger.error("Failed to remove SDC package: %r", result.stderr)
+            # We just exit here: it's not critical that the package is
+            # removed, and we don't want to block the charm removal by
+            # erroring on the remove event. The Juju log will show that the
+            # package removal failed, and the user can take action if needed.
+            return False
+        logger.info("SDC package removed successfully: %r", result.stdout)
+        return True
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,7 +35,7 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
         self.charm = self.harness.charm
 
-    def test__on_install(self):
+    def test_on_install(self):
         """Tests on installation the necessary methods are called."""
         # Don't want any actual installations occurring so mock it out
         # Note: this comes from the parent class where we simply don't want
@@ -50,7 +50,7 @@ class TestCharm(unittest.TestCase):
         self.charm.create_connector.assert_called_once()
         self.charm.install_sdc.assert_called_once()
 
-    def test__on_remove(self):
+    def test_on_remove(self):
         """Tests on removal the necessary methods are called."""
         # Don't want any actual installations occurring so mock it out
         # Note: this comes from the parent class where we simply don't want

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -50,6 +50,20 @@ class TestCharm(unittest.TestCase):
         self.charm.create_connector.assert_called_once()
         self.charm.install_sdc.assert_called_once()
 
+    def test__on_remove(self):
+        """Tests on removal the necessary methods are called."""
+        # Don't want any actual installations occurring so mock it out
+        # Note: this comes from the parent class where we simply don't want
+        # it trying to alter system state
+        self.charm.remove_connector = MagicMock()
+        self.charm.uninstall_sdc = MagicMock()
+
+        # Emit the remove hook
+        self.charm.on.remove.emit()
+
+        self.charm.remove_connector.assert_called_once()
+        self.charm.uninstall_sdc.assert_called_once()
+
     @patch("charm.mkdir")
     @patch("charm.render")
     def test_create_connector(self, _render, _mkdir):
@@ -158,4 +172,32 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.charm.unit.status, BlockedStatus("sdc-deb-package resource is missing")
+        )
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.remove")
+    def test_remove_connector(self, _remove, _exists):
+        """Test the connector removal."""
+        self.charm.remove_connector()
+
+        connecter_config_path = "/opt/emc/scaleio/openstack/connector.conf"
+        _exists.assert_called_once_with(connecter_config_path)
+        _remove.assert_called_once_with(connecter_config_path)
+
+    @patch("subprocess.run")
+    def test_uninstall_sdc(self, _subprocess_run):
+        """Test uninstalling the SDC package."""
+        self.charm._stored.installed = True
+        self.charm._stored.install_failed = False
+        self.charm._stored.sdc_package_name = "sdc-deb-package"
+
+        _subprocess_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        success = self.charm.uninstall_sdc()
+
+        self.assertTrue(success)
+        _subprocess_run.assert_called_once_with(
+            ["sudo", "apt", "remove", "-y", "sdc-deb-package"],
+            capture_output=True,
+            text=True,
         )


### PR DESCRIPTION
Observe the Juju `remove` event to clean up on charm removal. This is particularly desired on machine charms, and especially subordinate charms, as the machine will continue to exist after the charm is removed.

On remove:
 * Remove the configuration file if it exists.
 * Uninstall the Debian package if it was installed.